### PR TITLE
Bug: Scandir doesn't work if the directory doesn't exist

### DIFF
--- a/fs_s3fs/_s3fs.py
+++ b/fs_s3fs/_s3fs.py
@@ -705,6 +705,11 @@ class S3FS(FS):
         _s3_key = self._path_to_dir_key(_path)
         prefix_len = len(_s3_key)
 
+        if self.strict:
+            info = self.getinfo(path)
+            if not info.is_dir:
+                raise errors.DirectoryExpected(path)
+
         paginator = self.client.get_paginator("list_objects")
         _paginate = paginator.paginate(
             Bucket=self._bucket_name, Prefix=_s3_key, Delimiter=self.delimiter

--- a/fs_s3fs/_s3fs.py
+++ b/fs_s3fs/_s3fs.py
@@ -705,10 +705,6 @@ class S3FS(FS):
         _s3_key = self._path_to_dir_key(_path)
         prefix_len = len(_s3_key)
 
-        info = self.getinfo(path)
-        if not info.is_dir:
-            raise errors.DirectoryExpected(path)
-
         paginator = self.client.get_paginator("list_objects")
         _paginate = paginator.paginate(
             Bucket=self._bucket_name, Prefix=_s3_key, Delimiter=self.delimiter


### PR DESCRIPTION
In Scandir, remove code to check if the key is a exist and is a directory.  …
In some cases there is no directory exist as a key in S3, but still there are files in that directory.
This means only if the directory is explicitly exist `scandir` will work in it.
The check for file was removed this means file. will also be able to search any file that start with the same name. meaning shared prefix.